### PR TITLE
Added an option for escaping shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ preprocessors:
         protocol: https
         position: after_content
         date_format: year_first
+        escape_shortcodes: true
         escape_html: true
         template: |
             ## File History
@@ -67,6 +68,9 @@ preprocessors:
 
 `date_format`
 :   Output date format. If the default value `year_first` is used, the date “December 11, 2019” will be represented as `2019-12-11`. If the `day_first` value is used, this date will be represented as `11.12.2019`.
+
+`escape_shortcodes`
+:   Flag that tells the preprocessor to replace shortcodes with escaped shortcodes in diffs, for example: `{{< shortcode >}}` with `{{</* shortcode */>}}`.
 
 `escape_html`
 :   Flag that tells the preprocessor to replace HTML control characters with corresponding HTML entities in commit messages and diffs: `&` with `&amp;`, `<` with `&lt;`, `>` with `&gt;`, `"` with `&quot;`.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 1.0.5
+
+- add: option `escape_shortcodes`.
+
 # 1.0.4
 
 - fix: disabled escape html for diff

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description=SHORT_DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     long_description_content_type='text/markdown',
-    version='1.0.4',
+    version='1.0.5',
     author='Artemy Lomov',
     author_email='artemy@lomov.ru',
     url='https://github.com/foliant-docs/foliantcontrib.showcommits',


### PR DESCRIPTION
Added an option `escape_shortcodes`, enabled by default or enabled if backend hugo.
`escape_shortcodes` – makes shortcodes escaped in `diff` showcommits blocks.